### PR TITLE
configure source directories for checkstyle plugin

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -426,6 +426,10 @@
                 <version>3.2.1</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
+                    <sourceDirectories>
+                        <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                        <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
+                    </sourceDirectories>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Fix the problem that `target`-directory is checked by checkstyle